### PR TITLE
Update helpers for lists

### DIFF
--- a/src/controllers/searchController.ts
+++ b/src/controllers/searchController.ts
@@ -8,8 +8,10 @@ export class SearchController {
         return authors.join(" and ")
       } else if (authors.length > 2) {
         const allButLastAuthor = authors.slice(0, -1).join(", ")
-        const conjunction = "and "
-        return allButLastAuthor.concat(conjunction).concat(authors[-1])
+        const conjunction = ", and "
+        return allButLastAuthor
+          .concat(conjunction)
+          .concat(authors.slice(-1)[0])
       } else {
         return authors[0]
       }

--- a/src/controllers/searchController.ts
+++ b/src/controllers/searchController.ts
@@ -3,17 +3,26 @@ import { BookDataTransformer } from '../lib/bookDataTransformerService';
 
 export class SearchController {
   static helpers = {
-    listFormat: (authors: Array<string>) => {
+    joinAnd: (authors: Array<string>) => {
+      return authors.join(" and ")
+    },
+    joinIntoListWithAnd: (authors: Array<string>) => {
+      const allButLastAuthor = authors.slice(0, -1).join(", ")
+      const conjunction = ", and "
+      return allButLastAuthor
+        .concat(conjunction)
+        .concat(authors.slice(-1)[0])
+    },
+    singleAuthor: (authors: Array<string>) => {
+      return authors.slice(0)
+    },
+    formatForDisplay: (authors: Array<string>) => {
       if (authors.length === 2) {
-        return authors.join(" and ")
+        return SearchController.helpers.joinAnd(authors)
       } else if (authors.length > 2) {
-        const allButLastAuthor = authors.slice(0, -1).join(", ")
-        const conjunction = ", and "
-        return allButLastAuthor
-          .concat(conjunction)
-          .concat(authors.slice(-1)[0])
+        return SearchController.helpers.joinIntoListWithAnd(authors)
       } else {
-        return authors[0]
+        return SearchController.helpers.singleAuthor(authors)
       }
     }
   }
@@ -26,7 +35,10 @@ export class SearchController {
         const bookData = await BookDataTransformer.parseBookInfoList(rawData.items)
         res.status(200).render(
           'index', 
-          {books: bookData, listFormat: SearchController.helpers.listFormat}
+          { 
+            books: bookData,
+            formatForDisplay: SearchController.helpers.formatForDisplay
+          }
         );
       } catch(err) {
         console.log(err.message)

--- a/src/controllers/searchController.ts
+++ b/src/controllers/searchController.ts
@@ -3,19 +3,6 @@ import { BookDataTransformer } from '../lib/bookDataTransformerService';
 
 export class SearchController {
   static helpers = {
-    joinAnd: (authors: Array<string>) => {
-      return authors.join(" and ")
-    },
-    joinIntoListWithAnd: (authors: Array<string>) => {
-      const allButLastAuthor = authors.slice(0, -1).join(", ")
-      const conjunction = ", and "
-      return allButLastAuthor
-        .concat(conjunction)
-        .concat(authors.slice(-1)[0])
-    },
-    singleAuthor: (authors: Array<string>) => {
-      return authors.slice(0)
-    },
     formatForDisplay: (authors: Array<string>) => {
       if (authors.length === 2) {
         return SearchController.helpers.joinAnd(authors)
@@ -24,6 +11,16 @@ export class SearchController {
       } else {
         return SearchController.helpers.singleAuthor(authors)
       }
+    }, joinAnd: (authors: Array<string>) => {
+      return authors.join(" and ")
+    }, joinIntoListWithAnd: (authors: Array<string>) => {
+      const allButLastAuthor = authors.slice(0, -1).join(", ")
+      const conjunction = ", and "
+      return allButLastAuthor
+        .concat(conjunction)
+        .concat(authors.slice(-1)[0])
+    }, singleAuthor: (authors: Array<string>) => {
+      return authors.slice(0)
     }
   }
 

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -26,7 +26,7 @@ body
             .content
               a.header #{book.title}
               if book.authors
-                p Written By #{listFormat(book.authors)}
+                p Written By #{formatForDisplay(book.authors)}
             .meta
               if book.publisher
                 p Published by #{book.publisher}


### PR DESCRIPTION
This PR renames the `listFormat` helper to something more in-line with the helper's purpose. Much of the code from this helper was extracted to other methods to make it clearer what each branch of this formatting method will return.